### PR TITLE
Update get user endpoint

### DIFF
--- a/library/models.py
+++ b/library/models.py
@@ -53,7 +53,7 @@ class Sublayer(models.Model):
 
 class Commit(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    author = models.ForeignKey(Author, on_delete=models.SET_NULL, null=True, blank=True)
+    author = models.ForeignKey(Author, on_delete=models.SET_NULL, null=True, blank=True, related_name='commits')
     version = models.CharField(max_length=32)
     timestamp = models.DateTimeField()
     note = models.TextField()


### PR DESCRIPTION
GET user endpoint now returns more info for populating the user profile and takes in a `num_recent_commits` query param with default set to 5 recent commits. 

example: 
```json
{
    "user": {
        "pennKey": "soominp",
        "fullName": "Jacky Park",
        "assetsCreated": [
            {
                "name": "cartoonFish",
                "createdAt": "2025-02-10T00:14:28+00:00"
            },
            {
                "name": "cartoonFish",
                "createdAt": "2025-02-04T03:14:32+00:00"
            },
            {
                "name": "beegCrab",
                "createdAt": "2025-02-18T03:34:00+00:00"
            }
        ],
        "checkedOutAssets": [
            {
                "name": "cartoonFish",
                "checkedOutAt": "2025-02-10T00:14:28+00:00"
            },
            {
                "name": "cartoonFish",
                "checkedOutAt": "2025-02-04T03:14:32+00:00"
            },
            {
                "name": "beegCrab",
                "checkedOutAt": "2025-02-18T03:34:00+00:00"
            }
        ],
        "recentCommits": [
            {
                "assetName": "beegCrab",
                "version": "03.00.00",
                "note": "Converted LODs to a variant set",
                "timestamp": "2025-02-18T03:34:00+00:00"
            }
        ]
    }
}
```